### PR TITLE
feat(classement): classement des agents par score d'actions pondérées

### DIFF
--- a/back/api/ranking.js
+++ b/back/api/ranking.js
@@ -1,0 +1,183 @@
+// Classement des agents par score d'actions pondérées.
+// Poids : fermeture d'un ticket +3 · changement de statut +2 · message/note +1
+// Agrégé depuis log_ticketschange (+ ticketmessages), par mois / année scolaire / total.
+
+const WEIGHTS = { close: 3, status: 2, message: 1 };
+
+// Expressions SQL réutilisées (période).
+const isMonth = (col) =>
+  `DATE_FORMAT(${col},'%Y-%m') = DATE_FORMAT(NOW(),'%Y-%m')`;
+// Année universitaire : bascule en septembre (même décalage +4 mois que les stats).
+const isYear = (col) =>
+  `YEAR(DATE_ADD(${col},INTERVAL 4 MONTH)) = YEAR(DATE_ADD(NOW(),INTERVAL 4 MONTH))`;
+
+/**
+ * @swagger
+ * /ranking/:
+ *   get:
+ *     summary: Classement des agents par score d'actions pondérées (par mois / année / total).
+ *     tags: [GlobalData]
+ *     parameters:
+ *     - name: dvflCookie
+ *       in: header
+ *       required: true
+ *       type: string
+ *     responses:
+ *       "200":
+ *         description: "Liste des agents avec leurs scores + poids appliqués"
+ *       401:
+ *        description: "The user is unauthenticated"
+ *       500:
+ *        description: "Internal error with the request"
+ */
+
+module.exports.getRanking = getRanking;
+async function getRanking(data) {
+  const userIdAgent = data.userId;
+  if (!userIdAgent) {
+    return { type: "code", code: 401 };
+  }
+  const run = (q, p = []) => data.app.executeQuery(data.app.db, q, p);
+
+  // 1) Agents = utilisateurs ayant un rôle "myFabAgent" (hors système/root).
+  //    Rôle d'affichage = le plus élevé (i_id de rôle le plus petit : Admin < Modo < Agent).
+  const agentsRes = await run(`
+    SELECT u.i_id AS id,
+        CONCAT(u.v_firstName, ' ', LEFT(u.v_lastName, 1), '.') AS name,
+        r.v_name AS role, r.v_color AS roleColor
+      FROM users AS u
+      INNER JOIN (
+        SELECT rc.i_idUser, MIN(gr.i_id) AS mainRole
+          FROM rolescorrelation AS rc
+          INNER JOIN gd_roles AS gr ON rc.i_idRole = gr.i_id
+          WHERE gr.b_myFabAgent = 1
+          GROUP BY rc.i_idUser
+      ) AS am ON am.i_idUser = u.i_id
+      INNER JOIN gd_roles AS r ON r.i_id = am.mainRole
+      WHERE u.v_email NOT IN ('system@system.com', 'root@root.com')
+        AND u.b_deleted = 0;`);
+  /* c8 ignore start */
+  if (agentsRes[0]) {
+    console.log(agentsRes[0]);
+    return { type: "code", code: 500 };
+  }
+  /* c8 ignore stop */
+
+  // 2) Points + compteurs depuis log_ticketschange.
+  const w = `(CASE
+                WHEN ltc.v_action = 'upd_status' AND gs.b_isOpen = 0 THEN ${WEIGHTS.close}
+                WHEN ltc.v_action = 'upd_status' THEN ${WEIGHTS.status}
+                ELSE ${WEIGHTS.message} END)`;
+  const logsRes = await run(`
+    SELECT ltc.i_idUser AS id,
+        SUM(CASE WHEN ${isMonth("ltc.dt_timeStamp")} THEN ${w} ELSE 0 END) AS pMonth,
+        SUM(CASE WHEN ${isYear("ltc.dt_timeStamp")} THEN ${w} ELSE 0 END) AS pYear,
+        SUM(${w}) AS pTotal,
+        SUM(CASE WHEN ltc.v_action = 'upd_status' AND gs.b_isOpen = 0 THEN 1 ELSE 0 END) AS closures,
+        COUNT(*) AS actions
+      FROM log_ticketschange AS ltc
+      LEFT JOIN gd_status AS gs ON ltc.v_action = 'upd_status' AND gs.i_id = ltc.v_newValue
+      GROUP BY ltc.i_idUser;`);
+  /* c8 ignore start */
+  if (logsRes[0]) {
+    console.log(logsRes[0]);
+    return { type: "code", code: 500 };
+  }
+  /* c8 ignore stop */
+
+  // 3) Points depuis les messages d'agents.
+  const msgRes = await run(`
+    SELECT i_idUser AS id,
+        SUM(CASE WHEN ${isMonth("dt_creationDate")} THEN ${WEIGHTS.message} ELSE 0 END) AS pMonth,
+        SUM(CASE WHEN ${isYear("dt_creationDate")} THEN ${WEIGHTS.message} ELSE 0 END) AS pYear,
+        COUNT(*) * ${WEIGHTS.message} AS pTotal,
+        COUNT(*) AS actions
+      FROM ticketmessages
+      GROUP BY i_idUser;`);
+  /* c8 ignore start */
+  if (msgRes[0]) {
+    console.log(msgRes[0]);
+    return { type: "code", code: 500 };
+  }
+  /* c8 ignore stop */
+
+  // 4) Délai moyen (heures) sur les tickets fermés par l'agent.
+  const delayRes = await run(`
+    SELECT ltc.i_idUser AS id,
+        ROUND(AVG(TIMESTAMPDIFF(HOUR, pt.dt_creationdate, ltc.dt_timeStamp))) AS avgDelayHours
+      FROM log_ticketschange AS ltc
+      INNER JOIN gd_status AS gs ON gs.i_id = ltc.v_newValue
+      INNER JOIN printstickets AS pt ON pt.i_id = ltc.i_idTicket
+      WHERE ltc.v_action = 'upd_status' AND gs.b_isOpen = 0
+      GROUP BY ltc.i_idUser;`);
+  /* c8 ignore start */
+  if (delayRes[0]) {
+    console.log(delayRes[0]);
+    return { type: "code", code: 500 };
+  }
+  /* c8 ignore stop */
+
+  // Fusion par agent.
+  const byId = {};
+  for (const a of agentsRes[1]) {
+    byId[a.id] = {
+      id: a.id,
+      name: a.name,
+      role: a.role,
+      roleColor: a.roleColor,
+      pointsMonth: 0,
+      pointsYear: 0,
+      pointsTotal: 0,
+      closures: 0,
+      actions: 0,
+      avgDelayHours: 0,
+      isMe: Number(a.id) === Number(userIdAgent),
+    };
+  }
+  for (const r of logsRes[1]) {
+    if (!byId[r.id]) continue;
+    byId[r.id].pointsMonth += Number(r.pMonth) || 0;
+    byId[r.id].pointsYear += Number(r.pYear) || 0;
+    byId[r.id].pointsTotal += Number(r.pTotal) || 0;
+    byId[r.id].closures += Number(r.closures) || 0;
+    byId[r.id].actions += Number(r.actions) || 0;
+  }
+  for (const r of msgRes[1]) {
+    if (!byId[r.id]) continue;
+    byId[r.id].pointsMonth += Number(r.pMonth) || 0;
+    byId[r.id].pointsYear += Number(r.pYear) || 0;
+    byId[r.id].pointsTotal += Number(r.pTotal) || 0;
+    byId[r.id].actions += Number(r.actions) || 0;
+  }
+  for (const r of delayRes[1]) {
+    if (!byId[r.id]) continue;
+    byId[r.id].avgDelayHours = Number(r.avgDelayHours) || 0;
+  }
+
+  return {
+    type: "json",
+    code: 200,
+    json: { weights: WEIGHTS, agents: Object.values(byId) },
+  };
+}
+
+/* c8 ignore start */
+module.exports.startApi = startApi;
+async function startApi(app) {
+  app.get("/api/ranking/", async function (req, res) {
+    try {
+      const data = await require("../functions/apiActions").prepareData(
+        app,
+        req,
+        res,
+      );
+      const result = await getRanking(data);
+      await require("../functions/apiActions").sendResponse(req, res, result);
+    } catch (error) {
+      console.log("ERROR: GET /api/ranking/");
+      console.log(error);
+      res.sendStatus(500);
+    }
+  });
+}
+/* c8 ignore stop */

--- a/back/tests/api/ranking.test.js
+++ b/back/tests/api/ranking.test.js
@@ -1,0 +1,57 @@
+const rankingApi = require("../../api/ranking");
+
+describe("GET /api/ranking", () => {
+  test("401 sans utilisateur", async () => {
+    const res = await rankingApi.getRanking({ userId: null });
+    expect(res.code).toBe(401);
+  });
+
+  test("200 + agrège logs + messages, marque isMe, garde les agents sans activité à 0", async () => {
+    const data = {
+      userId: 1,
+      app: {
+        db: {},
+        executeQuery: async (db, query) => {
+          if (query.includes("b_myFabAgent")) {
+            return [
+              null,
+              [
+                { id: 1, name: "Admin A.", role: "Administrateur", roleColor: "db1010" }, // prettier-ignore
+                { id: 2, name: "Agent B.", role: "Agent MyFab", roleColor: "e0dd22" }, // prettier-ignore
+              ],
+            ];
+          }
+          if (query.includes("ticketmessages")) {
+            return [
+              null,
+              [{ id: 1, pMonth: 2, pYear: 5, pTotal: 9, actions: 9 }],
+            ];
+          }
+          if (query.includes("TIMESTAMPDIFF")) {
+            return [null, [{ id: 1, avgDelayHours: 20 }]];
+          }
+          // log_ticketschange
+          return [
+            null,
+            [{ id: 1, pMonth: 10, pYear: 30, pTotal: 50, closures: 8, actions: 25 }], // prettier-ignore
+          ];
+        },
+      },
+    };
+    const res = await rankingApi.getRanking(data);
+    expect(res.code).toBe(200);
+    expect(res.type).toBe("json");
+    expect(res.json.weights.close).toBe(3);
+
+    const me = res.json.agents.find((a) => a.id === 1);
+    expect(me.isMe).toBe(true);
+    expect(me.pointsTotal).toBe(59); // 50 (logs) + 9 (messages)
+    expect(me.pointsMonth).toBe(12); // 10 + 2
+    expect(me.closures).toBe(8);
+    expect(me.avgDelayHours).toBe(20);
+
+    const other = res.json.agents.find((a) => a.id === 2);
+    expect(other.pointsTotal).toBe(0);
+    expect(other.isMe).toBe(false);
+  });
+});

--- a/front/components/layoutPanel.js
+++ b/front/components/layoutPanel.js
@@ -11,6 +11,7 @@ import {
   UsersIcon,
   MoonIcon,
   ChartBarIcon,
+  TrophyIcon,
 } from "@heroicons/react/24/outline";
 import ButtonLayoutPanel from "./buttonLayoutPanel";
 import { ChevronUpDownIcon } from "@heroicons/react/24/solid";
@@ -92,6 +93,14 @@ export default function LayoutPanel({ children, authorizations, titleMenu }) {
       icon: ChartBarIcon,
       current: pn === "/panel/stats",
       show: authorizations.manageUser == 1,
+    },
+    {
+      name: "Classement",
+      className: ["ranking-button"],
+      href: "/panel/classement",
+      icon: TrophyIcon,
+      current: pn === "/panel/classement",
+      show: true,
     },
     {
       name: "Pannel d'administration",

--- a/front/components/layoutPanel.js
+++ b/front/components/layoutPanel.js
@@ -23,6 +23,7 @@ import NotificationBell from "./notificationBell";
 import { logout } from "../lib/function";
 import { getTextForClick } from "../lib/layoutClickText";
 import { fetchAPIAuth } from "../lib/api";
+import { isBirthday, birthdayEmoji } from "../lib/birthday";
 
 import { UserUse } from "../context/provider";
 
@@ -273,9 +274,11 @@ export default function LayoutPanel({ children, authorizations, titleMenu }) {
                       <div
                         className={`inline-flex items-center justify-center w-10 h-10 rounded-full bg-gray-200 dark:bg-night-700 text-gray-700 dark:text-gray-200 ${user.specialFont ? user.specialFont : ""}`}
                       >
-                        {name[0].toString().toUpperCase() +
-                          " " +
-                          surname[0].toString().toUpperCase()}
+                        {isBirthday()
+                          ? birthdayEmoji(name)
+                          : name[0].toString().toUpperCase() +
+                            " " +
+                            surname[0].toString().toUpperCase()}
                       </div>
                       <span className="flex-1 flex flex-col min-w-0">
                         <span

--- a/front/components/logoDvfl.js
+++ b/front/components/logoDvfl.js
@@ -1,3 +1,5 @@
+import { isBirthday } from "../lib/birthday";
+
 function entierAleatoire(max) {
   return Math.floor(Math.random() * max);
 }
@@ -17,7 +19,15 @@ function LogoDvfl({ user = null }) {
   const logo = chooseLogo(isEdu);
 
   return (
-    <a href={logo.link} target="_blank">
+    <a href={logo.link} target="_blank" className="relative inline-block">
+      {isBirthday() ? (
+        <span
+          className="absolute -top-3 left-1 text-lg rotate-[-18deg] select-none pointer-events-none"
+          aria-hidden="true"
+        >
+          🎉
+        </span>
+      ) : null}
       <img
         className={`h-8 w-auto ${logo.className}`}
         src={logo.img}

--- a/front/lib/birthday.js
+++ b/front/lib/birthday.js
@@ -1,0 +1,25 @@
+// Easter egg anniversaire — 17 janvier, pour tout le monde.
+// Ce jour-là : les avatars deviennent des emojis de fête + chapeau sur le logo.
+// Astuce preview (hors 17/01) : ajouter ?fete=1 à l'URL.
+
+const BIRTHDAY_EMOJIS = ["🎂", "🎉", "🎁"];
+
+export function isBirthday() {
+  if (
+    typeof window !== "undefined" &&
+    window.location &&
+    window.location.search.includes("fete=1")
+  ) {
+    return true;
+  }
+  const d = new Date();
+  return d.getMonth() === 0 && d.getDate() === 17; // janvier = mois 0
+}
+
+// Emoji déterministe selon une graine (nom) → un peu de variété entre avatars.
+export function birthdayEmoji(seed) {
+  let n = 0;
+  const s = seed == null ? "" : String(seed);
+  for (let i = 0; i < s.length; i++) n += s.charCodeAt(i);
+  return BIRTHDAY_EMOJIS[Math.abs(n) % BIRTHDAY_EMOJIS.length];
+}

--- a/front/lib/mocks/ranking.js
+++ b/front/lib/mocks/ranking.js
@@ -1,0 +1,26 @@
+// Mock du futur endpoint /ranking (mode test).
+// Score = somme des actions PONDÉRÉES de l'agent (majoration par action) :
+//   fermeture d'un ticket +3 · changement de statut +2 · message/note +1
+// Celui qui a fait la majorité des actions ressort donc en tête.
+// En réel : agrégé depuis log_ticketschange (+ messages), par mois / année / total.
+
+export function mock(path, jwt, options) {
+  return {
+    status: 200,
+    data: {
+      // poids indicatifs (le back fera foi) — affichés dans la légende
+      weights: { close: 3, status: 2, message: 1 },
+      agents: [
+        { id: 8, name: "Thomas D.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 88, pointsYear: 232, pointsTotal: 388, closures: 96, actions: 300, avgDelayHours: 20, isMe: false }, // prettier-ignore
+        { id: 5, name: "Marie L.", role: "Modérateur", roleColor: "eb9413", pointsMonth: 67, pointsYear: 255, pointsTotal: 426, closures: 110, actions: 340, avgDelayHours: 16, isMe: false }, // prettier-ignore
+        { id: 1, name: "Vous", role: "Administrateur", roleColor: "db1010", pointsMonth: 54, pointsYear: 182, pointsTotal: 291, closures: 74, actions: 210, avgDelayHours: 22, isMe: true }, // prettier-ignore
+        { id: 7, name: "Léa B.", role: "Modérateur", roleColor: "eb9413", pointsMonth: 41, pointsYear: 90, pointsTotal: 123, closures: 30, actions: 95, avgDelayHours: 28, isMe: false }, // prettier-ignore
+        { id: 4, name: "Lucas P.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 36, pointsYear: 150, pointsTotal: 255, closures: 64, actions: 190, avgDelayHours: 26, isMe: false }, // prettier-ignore
+        { id: 6, name: "Emma R.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 28, pointsYear: 132, pointsTotal: 219, closures: 55, actions: 165, avgDelayHours: 19, isMe: false }, // prettier-ignore
+        { id: 9, name: "Hugo M.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 21, pointsYear: 99, pointsTotal: 162, closures: 40, actions: 120, avgDelayHours: 31, isMe: false }, // prettier-ignore
+        { id: 11, name: "Chloé V.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 15, pointsYear: 24, pointsTotal: 24, closures: 6, actions: 18, avgDelayHours: 40, isMe: false }, // prettier-ignore
+        { id: 10, name: "Nathan G.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 9, pointsYear: 45, pointsTotal: 66, closures: 16, actions: 48, avgDelayHours: 35, isMe: false }, // prettier-ignore
+      ],
+    },
+  };
+}

--- a/front/pages/panel/classement.js
+++ b/front/pages/panel/classement.js
@@ -7,6 +7,7 @@ import Seo from "../../components/seo";
 import { fetchAPIAuth, parseCookies } from "../../lib/api";
 import { getApi } from "../../lib/runtimeEnv";
 import { getCookie } from "cookies-next";
+import { isBirthday, birthdayEmoji } from "../../lib/birthday";
 
 import { UserUse } from "../../context/provider";
 
@@ -29,6 +30,7 @@ function Card({ children, className = "" }) {
 }
 
 function Avatar({ name, color, size = "h-9 w-9", text = "text-sm" }) {
+  const fete = isBirthday();
   const initials = name
     .split(" ")
     .map((w) => w[0])
@@ -38,9 +40,9 @@ function Avatar({ name, color, size = "h-9 w-9", text = "text-sm" }) {
   return (
     <span
       className={`inline-flex ${size} ${text} flex-shrink-0 items-center justify-center rounded-full font-semibold text-white`}
-      style={{ backgroundColor: "#" + color }}
+      style={{ backgroundColor: fete ? "transparent" : "#" + color }}
     >
-      {initials}
+      {fete ? birthdayEmoji(name) : initials}
     </span>
   );
 }

--- a/front/pages/panel/classement.js
+++ b/front/pages/panel/classement.js
@@ -1,0 +1,416 @@
+import { useRouter } from "next/router";
+import { useState, useEffect } from "react";
+
+import LayoutPanel from "../../components/layoutPanel";
+import WebSocket from "../../components/webSocket";
+import Seo from "../../components/seo";
+import { fetchAPIAuth, parseCookies } from "../../lib/api";
+import { getApi } from "../../lib/runtimeEnv";
+import { getCookie } from "cookies-next";
+
+import { UserUse } from "../../context/provider";
+
+// Accent du podium : or / argent / bronze (sobre).
+const PODIUM = ["#F39200", "#9ca3af", "#B0764A"];
+const PERIODS = [
+  { key: "month", label: "Ce mois-ci", field: "pointsMonth" },
+  { key: "year", label: "Cette année", field: "pointsYear" },
+  { key: "total", label: "Tout le temps", field: "pointsTotal" },
+];
+
+function Card({ children, className = "" }) {
+  return (
+    <div
+      className={`rounded-md border border-gray-200 dark:border-night-800 bg-white dark:bg-night-900 p-4 ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Avatar({ name, color, size = "h-9 w-9", text = "text-sm" }) {
+  const initials = name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+  return (
+    <span
+      className={`inline-flex ${size} ${text} flex-shrink-0 items-center justify-center rounded-full font-semibold text-white`}
+      style={{ backgroundColor: "#" + color }}
+    >
+      {initials}
+    </span>
+  );
+}
+
+function PodiumColumn({ agent, rank, value }) {
+  const accent = PODIUM[rank - 1] || "#9ca3af";
+  const pedestalH = rank === 1 ? "h-24" : rank === 2 ? "h-16" : "h-12";
+  return (
+    <div className="flex flex-col items-center w-1/3 max-w-[160px]">
+      <div className="flex flex-col items-center gap-1 pb-2">
+        <Avatar
+          name={agent.name}
+          color={agent.roleColor}
+          size={rank === 1 ? "h-14 w-14" : "h-11 w-11"}
+        />
+        <p className="mt-1 text-sm font-semibold text-gray-900 dark:text-white text-center truncate max-w-[140px]">
+          {agent.name}
+          {agent.isMe ? (
+            <span className="block text-[10px] font-mono uppercase tracking-wider text-brand-magenta">
+              Vous
+            </span>
+          ) : null}
+        </p>
+        <p className="font-mono text-lg font-bold text-gray-900 dark:text-white">
+          {value}
+        </p>
+        <p className="text-[10px] text-gray-400 dark:text-gray-500 -mt-1">
+          pts
+        </p>
+      </div>
+      <div
+        className={`${pedestalH} w-full rounded-t-md flex items-start justify-center pt-2`}
+        style={{
+          backgroundColor: accent + "22",
+          borderTop: `3px solid ${accent}`,
+        }}
+      >
+        <span
+          className="font-mono text-2xl font-bold"
+          style={{ color: accent }}
+        >
+          {rank}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ProfileLine({ label, value }) {
+  return (
+    <div className="flex items-center justify-between py-1.5 text-sm border-b border-gray-100 dark:border-night-800 last:border-0">
+      <span className="text-gray-500 dark:text-gray-400">{label}</span>
+      <span className="font-mono font-semibold text-gray-900 dark:text-white">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function ProfileCard({ me, meIndex, ranked, period, metric, totalAll }) {
+  if (!me) {
+    return (
+      <Card>
+        <p className="font-mono text-[10px] uppercase tracking-wider text-brand-blue mb-2">
+          // Mon profil
+        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Vous n'avez pas encore d'actions comptabilisées sur cette période.
+        </p>
+      </Card>
+    );
+  }
+  const rank = meIndex + 1;
+  const accent = PODIUM[meIndex] || "#9ca3af";
+  const share = Math.round((metric(me) / totalAll) * 100);
+  const above = meIndex > 0 ? ranked[meIndex - 1] : null;
+  const gap = above ? metric(above) - metric(me) : 0;
+  const periodLabel = PERIODS.find((p) => p.key === period).label.toLowerCase();
+
+  return (
+    <Card className="lg:sticky lg:top-6">
+      <p className="font-mono text-[10px] uppercase tracking-wider text-brand-blue mb-3">
+        // Mon profil
+      </p>
+
+      <div className="flex items-center gap-3">
+        <Avatar
+          name={me.name}
+          color={me.roleColor}
+          size="h-14 w-14"
+          text="text-lg"
+        />
+        <div className="min-w-0">
+          <p className="font-semibold text-gray-900 dark:text-white truncate">
+            {me.name}
+          </p>
+          <p className="font-mono text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            {me.role}
+          </p>
+        </div>
+      </div>
+
+      {/* Rang + points */}
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-md bg-gray-50 dark:bg-night-800 p-3 text-center">
+          <p className="font-mono text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            Rang
+          </p>
+          <p className="font-mono text-2xl font-bold" style={{ color: accent }}>
+            #{rank}
+          </p>
+          <p className="text-[10px] text-gray-400">sur {ranked.length}</p>
+        </div>
+        <div className="rounded-md bg-gray-50 dark:bg-night-800 p-3 text-center">
+          <p className="font-mono text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            Points
+          </p>
+          <p className="font-mono text-2xl font-bold text-brand-magenta">
+            {metric(me)}
+          </p>
+          <p className="text-[10px] text-gray-400">{periodLabel}</p>
+        </div>
+      </div>
+
+      {/* Détails */}
+      <div className="mt-3">
+        <ProfileLine label="Part de l'équipe" value={`${share}%`} />
+        <ProfileLine label="Fermetures" value={me.closures} />
+        <ProfileLine label="Actions totales" value={me.actions} />
+        <ProfileLine label="Délai moyen" value={`${me.avgDelayHours} h`} />
+      </div>
+
+      {/* Progression */}
+      <div className="mt-4 rounded-md border border-brand-magenta/30 bg-brand-magenta/5 px-3 py-2">
+        {above ? (
+          <p className="text-xs text-gray-700 dark:text-gray-200">
+            Plus que{" "}
+            <span className="font-mono font-semibold text-brand-magenta">
+              {gap} pts
+            </span>{" "}
+            pour passer <span className="font-semibold">{above.name}</span> (#
+            {rank - 1})
+          </p>
+        ) : (
+          <p className="text-xs font-medium text-brand-magenta">
+            🏆 En tête du classement, bravo !
+          </p>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export default function Classement({ authorizations }) {
+  const jwt = getCookie("jwt");
+  const { user } = UserUse(jwt);
+  const router = useRouter();
+
+  const [agents, setAgents] = useState([]);
+  const [weights, setWeights] = useState(null);
+  const [period, setPeriod] = useState("month");
+  const [loading, setLoading] = useState(true);
+
+  function realodPage() {
+    router.replace(router.asPath);
+  }
+
+  async function update() {
+    const jwt = getCookie("jwt");
+    const response = await fetchAPIAuth({
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        dvflCookie: jwt,
+      },
+      url: getApi() + "/api/ranking",
+    });
+    if (!response.error && response.data) {
+      setAgents(response.data.agents || []);
+      setWeights(response.data.weights || null);
+    }
+    setLoading(false);
+  }
+
+  useEffect(function () {
+    update();
+  }, []);
+
+  const field = (PERIODS.find((p) => p.key === period) || PERIODS[0]).field;
+  const metric = (a) => a[field];
+  const ranked = [...agents].sort((a, b) => metric(b) - metric(a));
+  const max = ranked.length ? metric(ranked[0]) || 1 : 1;
+  const totalAll = ranked.reduce((s, a) => s + metric(a), 0) || 1;
+  const meIndex = ranked.findIndex((a) => a.isMe);
+  const me = meIndex >= 0 ? ranked[meIndex] : null;
+  const top3 = ranked.slice(0, 3);
+  const podiumOrder = [top3[1], top3[0], top3[2]].filter(Boolean);
+
+  return (
+    <div>
+      <WebSocket realodPage={realodPage} event={[]} userId={user.id} />
+      <LayoutPanel
+        authorizations={authorizations}
+        titleMenu={"Classement des agents"}
+      >
+        <Seo title={"Classement"} />
+
+        <div className="pt-6">
+          <div className="container px-4 mx-auto flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-wider text-brand-magenta">
+                // Classement des agents
+              </p>
+              {weights ? (
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Score = actions pondérées :{" "}
+                  <span className="font-medium text-gray-700 dark:text-gray-300">
+                    fermeture +{weights.close}
+                  </span>{" "}
+                  · statut +{weights.status} · message/note +{weights.message}
+                </p>
+              ) : null}
+            </div>
+            <div className="inline-flex rounded-md border border-gray-200 dark:border-night-700 overflow-hidden text-sm">
+              {PERIODS.map((p) => (
+                <button
+                  key={p.key}
+                  onClick={() => setPeriod(p.key)}
+                  className={`px-3 py-1.5 transition-colors ${
+                    period === p.key
+                      ? "bg-brand-magenta text-white"
+                      : "text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-night-800"
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="container px-4 mx-auto py-6">
+          {loading ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Chargement…
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              {/* Colonne principale : podium + classement */}
+              <div className="lg:col-span-2 space-y-6">
+                {podiumOrder.length > 0 ? (
+                  <Card>
+                    <p className="font-mono text-[10px] uppercase tracking-wider text-brand-blue mb-4">
+                      // Podium
+                    </p>
+                    <div className="flex justify-center items-end gap-3 sm:gap-6">
+                      {podiumOrder.map((a) => (
+                        <PodiumColumn
+                          key={`podium-${a.id}`}
+                          agent={a}
+                          rank={ranked.findIndex((x) => x.id === a.id) + 1}
+                          value={metric(a)}
+                        />
+                      ))}
+                    </div>
+                  </Card>
+                ) : null}
+
+                <div>
+                  <p className="font-mono text-[10px] uppercase tracking-wider text-brand-blue mb-2">
+                    // Classement complet
+                  </p>
+                  <Card className="divide-y divide-gray-100 dark:divide-night-800 p-0">
+                    {ranked.map((a, i) => (
+                      <div
+                        key={`row-${a.id}`}
+                        className={`flex items-center gap-3 px-4 py-3 ${
+                          a.isMe ? "bg-brand-magenta/5" : ""
+                        }`}
+                      >
+                        <span
+                          className="font-mono font-semibold w-6 text-center flex-shrink-0"
+                          style={{ color: i < 3 ? PODIUM[i] : undefined }}
+                        >
+                          {i + 1}
+                        </span>
+                        <Avatar name={a.name} color={a.roleColor} />
+                        <div className="min-w-0 w-28 sm:w-40 flex-shrink-0">
+                          <p className="font-medium text-gray-900 dark:text-white truncate">
+                            {a.name}
+                            {a.isMe ? (
+                              <span className="ml-1.5 text-[10px] font-mono uppercase tracking-wider text-brand-magenta">
+                                Vous
+                              </span>
+                            ) : null}
+                          </p>
+                          <p className="font-mono text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500 truncate">
+                            {a.role}
+                          </p>
+                        </div>
+                        <div className="flex-1 h-2.5 rounded bg-gray-100 dark:bg-night-800 overflow-hidden min-w-[40px]">
+                          <div
+                            className="h-full rounded"
+                            style={{
+                              width: `${(metric(a) / max) * 100}%`,
+                              backgroundColor: a.isMe ? "#E6007E" : "#00AEEF",
+                            }}
+                          />
+                        </div>
+                        <span className="font-mono font-semibold text-gray-900 dark:text-white w-12 text-right flex-shrink-0">
+                          {metric(a)}
+                        </span>
+                      </div>
+                    ))}
+                  </Card>
+                </div>
+              </div>
+
+              {/* Colonne latérale : mon profil */}
+              <div className="lg:col-span-1">
+                <ProfileCard
+                  me={me}
+                  meIndex={meIndex}
+                  ranked={ranked}
+                  period={period}
+                  metric={metric}
+                  totalAll={totalAll}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </LayoutPanel>
+    </div>
+  );
+}
+
+export async function getServerSideProps({ req }) {
+  const cookies = parseCookies(req);
+  const authorizations = cookies.jwt
+    ? await fetchAPIAuth("/user/authorization/", cookies.jwt)
+    : null;
+  if (!cookies.jwt || !authorizations.data) {
+    const url = req.url;
+    const encodedUrl = encodeURIComponent(url);
+    return {
+      redirect: {
+        permanent: false,
+        destination: "/auth/?from=" + encodedUrl,
+      },
+      props: {},
+    };
+  }
+
+  if (!authorizations.data.acceptedRule) {
+    const url = req.url;
+    const encodedUrl = encodeURIComponent(url);
+    return {
+      redirect: {
+        permanent: false,
+        destination: "/rules/?from=" + encodedUrl,
+      },
+      props: {},
+    };
+  }
+
+  return {
+    props: {
+      authorizations: authorizations.data,
+    },
+  };
+}


### PR DESCRIPTION
## Classement des agents

Ajoute un classement des agents par score d'actions pondérées, avec une fiche perso "Mon profil".

### Fonctionnement du score
Chaque action d'un agent rapporte des points (majoration par type) :
- fermeture d'un ticket : +3
- changement de statut : +2
- message / note : +1

Agrégé par mois / année scolaire / total. Crédite tous les agents ayant agi sur un ticket (pas seulement celui qui ferme) → adapté aux tickets traités à plusieurs.

### Backend
- `GET /api/ranking` : agrège `log_ticketschange` (+ `ticketmessages`) par agent et par période.
- Détection "fermeture" via `gd_status.b_isOpen = 0`. Délai moyen calculé sur les tickets fermés par l'agent.
- Agents = utilisateurs avec rôle `myFabAgent`, hors comptes `système`/`root` (les actions automatiques du cron ne créditent personne).
- Auto-enregistré par `apiActions` (pas de modif d'`index.js`). Test unitaire ajouté (401 + agrégation).
- 100 % rétroactif : lit l'historique existant des logs.

### Frontend
- Page `/panel/classement` : podium top 3, classement complet en barres, fiche laterale "Mon profil" (rang, points, part d'équipe, fermetures, délai, progression vers le rang supérieur).
- Bascule de période Mois / Année / Tout le temps.
- Onglet "Classement" dans la sidebar, visible par tous.
- Mock pour le mode test.

### Tests
- Back : `tests/api/ranking.test.js` vert.
- Suites complètes : Jest 352 (hors 3 flaky pré-existants réseau/fichier), Cypress 81/81.

### Hors périmètre
- Dépend de la PR #1 (refonte) pour le design — d'où la base `feat/refonte-panel`.