### PR TITLE
fix(classement): masquer les 0 par periode + garder les anciens agents

### DIFF
--- a/back/api/ranking.js
+++ b/back/api/ranking.js
@@ -49,23 +49,30 @@ async function getRanking(data) {
   }
   const run = (q, p = []) => data.app.executeQuery(data.app.db, q, p);
 
-  // 1) Agents = utilisateurs ayant un rôle "myFabAgent" (hors système/root).
+  // 1) Agents = utilisateurs ayant un rôle "myFabAgent" (hors système/root)
+  //    OU ayant déjà eu de l'activité (anciens agents qui ont perdu le rôle).
   //    Rôle d'affichage = le plus élevé (i_id de rôle le plus petit : Admin < Modo < Agent).
+  //    Un ancien agent (plus de rôle myFabAgent) a role = NULL -> "Ancien agent".
   const agentsRes = await run(`
     SELECT u.i_id AS id,
         CONCAT(u.v_firstName, ' ', LEFT(u.v_lastName, 1), '.') AS name,
         r.v_name AS role, r.v_color AS roleColor
       FROM users AS u
-      INNER JOIN (
+      LEFT JOIN (
         SELECT rc.i_idUser, MIN(gr.i_id) AS mainRole
           FROM rolescorrelation AS rc
           INNER JOIN gd_roles AS gr ON rc.i_idRole = gr.i_id
           WHERE gr.b_myFabAgent = 1
           GROUP BY rc.i_idUser
       ) AS am ON am.i_idUser = u.i_id
-      INNER JOIN gd_roles AS r ON r.i_id = am.mainRole
+      LEFT JOIN gd_roles AS r ON r.i_id = am.mainRole
       WHERE u.v_email NOT IN ('system@system.com', 'root@root.com')
-        AND u.b_deleted = 0;`);
+        AND u.b_deleted = 0
+        AND (
+          am.i_idUser IS NOT NULL
+          OR u.i_id IN (SELECT DISTINCT i_idUser FROM log_ticketschange)
+          OR u.i_id IN (SELECT DISTINCT i_idUser FROM ticketmessages)
+        );`);
   /* c8 ignore start */
   if (agentsRes[0]) {
     console.log(agentsRes[0]);
@@ -133,8 +140,10 @@ async function getRanking(data) {
     byId[a.id] = {
       id: a.id,
       name: a.name,
-      role: a.role,
-      roleColor: a.roleColor,
+      // Ancien agent (plus de rôle myFabAgent) : libellé + couleur neutres.
+      role: a.role || "Ancien agent",
+      roleColor: a.roleColor || "9ca3af",
+      former: !a.role,
       pointsMonth: 0,
       pointsYear: 0,
       pointsTotal: 0,

--- a/back/tests/api/ranking.test.js
+++ b/back/tests/api/ranking.test.js
@@ -27,6 +27,7 @@ describe("GET /api/ranking", () => {
               [
                 { id: 1, name: "Admin A.", role: "Administrateur", roleColor: "db1010" }, // prettier-ignore
                 { id: 2, name: "Agent B.", role: "Agent MyFab", roleColor: "e0dd22" }, // prettier-ignore
+                { id: 3, name: "Ancien C.", role: null, roleColor: null }, // ancien agent (plus de rôle) // prettier-ignore
               ],
             ];
           }
@@ -42,7 +43,10 @@ describe("GET /api/ranking", () => {
           // log_ticketschange
           return [
             null,
-            [{ id: 1, pMonth: 10, pYear: 30, pTotal: 50, closures: 8, actions: 25 }], // prettier-ignore
+            [
+              { id: 1, pMonth: 10, pYear: 30, pTotal: 50, closures: 8, actions: 25 }, // prettier-ignore
+              { id: 3, pMonth: 0, pYear: 0, pTotal: 12, closures: 1, actions: 4 }, // prettier-ignore
+            ],
           ];
         },
       },
@@ -61,5 +65,12 @@ describe("GET /api/ranking", () => {
 
     // l'agent sans aucune action est exclu du classement
     expect(res.json.agents.find((a) => a.id === 2)).toBeUndefined();
+
+    // un ancien agent (plus de rôle) garde son activité et est affiché
+    const former = res.json.agents.find((a) => a.id === 3);
+    expect(former).toBeDefined();
+    expect(former.former).toBe(true);
+    expect(former.role).toBe("Ancien agent");
+    expect(former.pointsTotal).toBe(12);
   });
 });

--- a/front/lib/mocks/ranking.js
+++ b/front/lib/mocks/ranking.js
@@ -20,6 +20,9 @@ export function mock(path, jwt, options) {
         { id: 9, name: "Hugo M.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 21, pointsYear: 99, pointsTotal: 162, closures: 40, actions: 120, avgDelayHours: 31, isMe: false }, // prettier-ignore
         { id: 11, name: "Chloé V.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 15, pointsYear: 24, pointsTotal: 24, closures: 6, actions: 18, avgDelayHours: 40, isMe: false }, // prettier-ignore
         { id: 10, name: "Nathan G.", role: "Agent MyFab", roleColor: "e0dd22", pointsMonth: 9, pointsYear: 45, pointsTotal: 66, closures: 16, actions: 48, avgDelayHours: 35, isMe: false }, // prettier-ignore
+        // Ancien agent : plus de rôle myFabAgent mais activité conservée.
+        // pointsMonth/Year = 0 -> n'apparaît que dans "Tout le temps".
+        { id: 12, name: "Antoine F.", role: "Ancien agent", roleColor: "9ca3af", former: true, pointsMonth: 0, pointsYear: 0, pointsTotal: 140, closures: 34, actions: 102, avgDelayHours: 24, isMe: false }, // prettier-ignore
       ],
     },
   };

--- a/front/pages/panel/classement.js
+++ b/front/pages/panel/classement.js
@@ -63,7 +63,13 @@ function tierForRank(index, total) {
   return TIERS[Math.min(index, TIERS.length - 1)];
 }
 
-function RankBadge({ index, total, size = 22, showLabel = true }) {
+function RankBadge({
+  index,
+  total,
+  size = 22,
+  showLabel = true,
+  stacked = false,
+}) {
   const t = tierForRank(index, total);
   // Slug du sous-tier (radiant, immortal-3, ascendant-1, iron-1…) pour l'image.
   const slug = t.n.toLowerCase().replace(/\s+/g, "-");
@@ -71,7 +77,14 @@ function RankBadge({ index, total, size = 22, showLabel = true }) {
   // true = on tente l'image ; sur erreur (fichier absent) → repli sur le losange.
   const [imgOk, setImgOk] = useState(true);
   return (
-    <span className="inline-flex items-center gap-1.5" title={t.n}>
+    <span
+      className={
+        stacked
+          ? "inline-flex flex-col items-center gap-1.5"
+          : "inline-flex items-center gap-1.5"
+      }
+      title={t.n}
+    >
       {imgOk ? (
         <img
           src={imgSrc}
@@ -98,7 +111,9 @@ function RankBadge({ index, total, size = 22, showLabel = true }) {
       )}
       {showLabel ? (
         <span
-          className="font-mono text-[10px] uppercase tracking-wider whitespace-nowrap"
+          className={`font-mono uppercase tracking-wider whitespace-nowrap ${
+            stacked ? "text-xs font-semibold" : "text-[10px]"
+          }`}
           style={{ color: t.l }}
         >
           {t.n}
@@ -234,8 +249,10 @@ function ProfileCard({ me, meIndex, ranked, period, metric, totalAll }) {
         </div>
       </div>
 
-      <div className="mt-3 flex justify-center">
-        <RankBadge index={meIndex} total={ranked.length} size={26} />
+      <div className="mt-4 flex justify-center">
+        <div className="flex flex-col items-center rounded-md border border-gray-200 dark:border-night-800 bg-gray-50 dark:bg-night-800 px-8 py-4">
+          <RankBadge index={meIndex} total={ranked.length} size={72} stacked />
+        </div>
       </div>
 
       {/* Rang + points */}

--- a/front/pages/panel/classement.js
+++ b/front/pages/panel/classement.js
@@ -327,7 +327,11 @@ export default function Classement({ authorizations }) {
 
   const field = (PERIODS.find((p) => p.key === period) || PERIODS[0]).field;
   const metric = (a) => a[field];
-  const ranked = [...agents].sort((a, b) => metric(b) - metric(a));
+  // On ne montre que les agents avec un score > 0 SUR LA PÉRIODE choisie
+  // (un agent inactif ce mois-ci ne doit pas apparaître à 0).
+  const ranked = [...agents]
+    .filter((a) => metric(a) > 0)
+    .sort((a, b) => metric(b) - metric(a));
   const max = ranked.length ? metric(ranked[0]) || 1 : 1;
   const totalAll = ranked.reduce((s, a) => s + metric(a), 0) || 1;
   const meIndex = ranked.findIndex((a) => a.isMe);


### PR DESCRIPTION
- front: ne lister que les agents avec un score > 0 sur la periode affichee (un agent inactif ce mois-ci n'apparait plus a 0)
- back: inclure les anciens agents (activite dans les logs mais plus de role myFabAgent), affiches avec le libelle "Ancien agent"
- test + mock a jour